### PR TITLE
Publish to  public.ecr.aws/citizensadvice/mokta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
       - main
       - "[0-9]*"
       - "v[0-9]*"
-
+    tags:
+      - v*
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Build and publish to public ECR
+
+# Controls when the action will run. 
+on: [push,workflow_dispatch]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Push to public ECR
+      uses: citizensadvice/publish-to-public-ecr-github-action@main
+      id: ecr
+      with:
+        aws-access-key-id: ${{ secrets.PUBLIC_PUSH_ECR_AWS_KEY}}
+        aws-secret-access-key: ${{ secrets.PUBLIC_PUSH_ECR_AWS_SECRET }}
+        ecr-alias: citizensadvice

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN \
   apk --no-cache add \
     gcc \
     make \
-    libc-dev
+    libc-dev \
+    libxml2 \
+    patch
 
 ADD Gemfile* ./
 


### PR DESCRIPTION
Also fixes the failing nokogiri install in the Docker build.

Once merged this code will replace the docker hub build pipeline with one which publishes the mokta image to AWS, see https://github.com/citizensadvice/mokta/pull/13/files